### PR TITLE
Remove errant call to AllocateTensors during model init

### DIFF
--- a/qa/helpers/triton_model_config.py
+++ b/qa/helpers/triton_model_config.py
@@ -1,6 +1,7 @@
 # Copyright © 2021 Arm Ltd and Contributors. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+from jinja2 import Template
 
 class Model:
     def __init__(self, name, inputs, outputs, gpu=0, cpu=1, max_batch_size=0):
@@ -44,3 +45,26 @@ class TFLiteTritonModel(Model):
         self.armnn_gpu_parameters = armnn_gpu_parameters
         self.xnnpack = xnnpack
         self.xnnpack_parameters = xnnpack_parameters
+      
+        
+def load_model(inference_client, model_config, model_repo_path):
+    if inference_client.is_model_ready(model_config.name):
+        inference_client.unload_model(model_config.name)
+        
+    if model_config and model_repo_path:
+
+        with open("config-template.pbtxt") as file_:
+            template = Template(
+                file_.read(),
+                trim_blocks=True,
+                lstrip_blocks=True,
+                keep_trailing_newline=True,
+            )
+        output_config = template.render(model=model_config)
+        with open(
+            f"{model_repo_path}/{model_config.name}/config.pbtxt",
+            "w+",
+        ) as output_file_:
+            output_file_.write(output_config)
+
+    inference_client.load_model(model_config.name)

--- a/qa/tests/basic_model_test.py
+++ b/qa/tests/basic_model_test.py
@@ -4,7 +4,6 @@
 import pytest
 
 import numpy as np
-import os
 
 import tritonclient.http as httpclient
 import tritonclient.grpc as grpcclient
@@ -15,6 +14,8 @@ from helpers.triton_model_config import Model, TFLiteTritonModel
 
 
 def basic_test(model_config, inference_client, client_type, input_value, expected):
+    assert inference_client.is_model_ready(model_config.name)
+    
     request_inputs = []
     for input in model_config.inputs:
         request_input = client_type.InferInput(

--- a/qa/tests/image_classification_model_test.py
+++ b/qa/tests/image_classification_model_test.py
@@ -23,6 +23,8 @@ def classification_net(
     scaling,
     batching,
 ):
+    assert inference_client.is_model_ready(model_config.name)
+    
     image_input = model_config.inputs[0]
 
     if (
@@ -331,7 +333,6 @@ def test_inceptionv3(
         "inception",
         False,
     )
-
 
 @pytest.mark.parametrize(
     "model_config",

--- a/qa/tests/model_load_test.py
+++ b/qa/tests/model_load_test.py
@@ -1,0 +1,43 @@
+# Copyright © 2023 Arm Ltd and Contributors. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+import tritonclient.http as httpclient
+import tritonclient.grpc as grpcclient
+
+from itertools import product
+
+from helpers.triton_model_config import Model, TFLiteTritonModel, load_model
+
+
+@pytest.mark.parametrize(
+    "model_config",
+    [
+        TFLiteTritonModel(
+            "inceptionv3_dynamic",
+            [Model.TensorIO("serving_default_inputs:0", "TYPE_FP32", [299, 299, 3])],
+            [
+                Model.TensorIO(
+                    "StatefulPartitionedCall:0",
+                    "TYPE_FP32",
+                    [1001],
+                )
+            ],
+            armnn_cpu=armnn_on,
+            xnnpack=xnnpack_on,
+        )
+        for (armnn_on, xnnpack_on) in list(product([True, False], [True, False]))
+        if not (xnnpack_on and armnn_on)
+    ],
+)
+@pytest.mark.parametrize("client_type", [httpclient, grpcclient])
+def test_inceptionv3_dynamic(tritonserver, inference_client, model_config, request):
+    if model_config.xnnpack or model_config.armnn_cpu:
+        pytest.xfail(
+            "XNNPACK/ArmNN not supported on dynamic sized non-batch dimensions for input tensor shapes"
+        )
+    load_model(
+        inference_client, model_config, request.config.getoption("model_repo_path")
+    )
+    assert inference_client.is_model_ready(model_config.name)

--- a/qa/tests/object_detection_model_test.py
+++ b/qa/tests/object_detection_model_test.py
@@ -23,6 +23,8 @@ def object_detection_net(
     model_config,
     scaling,
 ):
+    assert inference_client.is_model_ready(model_config.name)
+    
     image_input = model_config.inputs[0]
     request_input = client_type.InferInput(
         image_input.name, [1, image_input.dims[1], image_input.dims[1], 3], "FP32"

--- a/src/tflite.cc
+++ b/src/tflite.cc
@@ -748,16 +748,6 @@ ModelInstanceState::BuildInterpreter()
     LogDelegation("xnnpack");
   }
 
-
-  // Allocate memory for input and output tensors
-  if (interpreter_->AllocateTensors() != kTfLiteOk) {
-    return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INTERNAL,
-        ("TfLite interpreter failed to allocate tensor inputs for model " +
-         Name())
-            .c_str());
-  }
-
   return nullptr;
 }
 


### PR DESCRIPTION
This fixes an issue when loading a model containing dynamic input dimensions outside of the batch dimension.

It's ensured that AllocateTensors will only be called once the shape of the input tensor is set via ResizeInputTensor.